### PR TITLE
added maxsplit=1 to account for = use in user comments

### DIFF
--- a/nanonispy/read.py
+++ b/nanonispy/read.py
@@ -595,7 +595,7 @@ def _split_header_entry(entry, multiple=False):
     those by ';' character.
     """
 
-    _, val_str = entry.split("=")
+    _, val_str = entry.split("=", 1)
 
     if multiple:
         return val_str.strip('"').split(';')


### PR DESCRIPTION
Hi,

Thanks for writing this, terribly useful!  We hit an error when there's an equal sign in the user comment box for 3ds files; I corrected it by adding a maxsplit=1, not sure if this adversely affects other aspects of parsing the header.

Regards,

Jack