### PR TITLE
.sxm flip backward scan

### DIFF
--- a/nanonispy/read.py
+++ b/nanonispy/read.py
@@ -362,7 +362,7 @@ class Scan(NanonisFile):
         # extract data for each channel
         for i, chann in enumerate(channs):
             chann_dict = dict(forward=scandata_shaped[i, 0, :, :],
-                              backward=scandata_shaped[i, 1, :, :])
+                              backward=np.fliplr(scandata_shaped[i, 1, :, :]))
             data_dict[chann] = chann_dict
 
         return data_dict


### PR DESCRIPTION
Software version: Generig 5e (R11948)

In my case, if I want to plot forward & backward scan of my STM.sxm measurement, I have to flip the backward scan to have forward & backward scan in the same orientation.