### PR TITLE
fix: incompatibility with numpy 1.24

### DIFF
--- a/nanonispy/read.py
+++ b/nanonispy/read.py
@@ -633,11 +633,11 @@ def _parse_sxm_header(header_raw):
 
     for key in entries_to_be_floated:
         if isinstance(header_dict[key], list):
-            header_dict[key] = np.asarray(header_dict[key], dtype=np.float)
+            header_dict[key] = np.asarray(header_dict[key], dtype=float)
         else:
-            header_dict[key] = np.float(header_dict[key])
+            header_dict[key] = float(header_dict[key])
     for key in entries_to_be_inted:
-        header_dict[key] = np.asarray(header_dict[key], dtype=np.int)
+        header_dict[key] = np.asarray(header_dict[key], dtype=int)
 
     return header_dict
 


### PR DESCRIPTION
The deprecation for the aliases np.float and np.int was expired in numpy 1.24. https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations