### PR TITLE
changing np.float to float

### DIFF
--- a/nanonispy/read.py
+++ b/nanonispy/read.py
@@ -257,7 +257,7 @@ class Grid(NanonisFile):
         sweep_start, sweep_end = self.signals['params'][0, 0, :2]
         num_sweep_signal = self.header['num_sweep_signal']
 
-        return np.linspace(sweep_start, sweep_end, num_sweep_signal, dtype=np.float32)
+        return np.linspace(sweep_start, sweep_end, num_sweep_signal, dtype=float)
 
     def _extract_topo(self):
         """
@@ -633,11 +633,11 @@ def _parse_sxm_header(header_raw):
 
     for key in entries_to_be_floated:
         if isinstance(header_dict[key], list):
-            header_dict[key] = np.asarray(header_dict[key], dtype=np.float)
+            header_dict[key] = np.asarray(header_dict[key], dtype=float)
         else:
-            header_dict[key] = np.float(header_dict[key])
+            header_dict[key] = float(header_dict[key])
     for key in entries_to_be_inted:
-        header_dict[key] = np.asarray(header_dict[key], dtype=np.int)
+        header_dict[key] = np.asarray(header_dict[key], dtype=int)
 
     return header_dict
 

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -319,10 +319,10 @@ class TestScanFile(unittest.TestCase):
                 a = value
                 b = np.fromstring(test_dict[key].strip('[]'), sep=' ')
                 np.testing.assert_almost_equal(a, b)
-            elif isinstance(value, np.float):
+            elif isinstance(value, float):
                 print(key, value)
                 a = value
-                b = np.float(test_dict[key])
+                b = float(test_dict[key])
                 np.testing.assert_almost_equal(a, b)
                 print(key, value)
             else:


### PR DESCRIPTION
np.float, np.int and np.complex are all deprecated in numpy 1.20. It is suggested to change these to float(), int() and complex() to avoid warnings during test (and potentially future errors).  This update passes the tests without warnings (see below).

```
(base) D:\Github\nanonispy>pytest
================================================= test session starts =================================================
platform win32 -- Python 3.9.13, pytest-7.1.2, pluggy-1.0.0
rootdir: D:\Github\nanonispy
plugins: anyio-3.5.0
collected 26 items

tests\test_read.py ..........................                                                                    [100%]

================================================= 26 passed in 6.60s ==================================================
```
